### PR TITLE
add link to transaction confirmation guide in sticky comment

### DIFF
--- a/SwapNSalebot.py
+++ b/SwapNSalebot.py
@@ -14,7 +14,7 @@ WAIT = 20
 COMMENT_TEMPLATE = """
 **It's dangerous to go alone! Take this.**
 
-[Avoiding Scams] (https://www.reddit.com/r/GameSale/wiki/avoidscams) | [Universal Scammer List](https://universalscammerlist.com/search.php)
+[Avoiding Scams] (https://www.reddit.com/r/GameSale/wiki/avoidscams) | [Universal Scammer List](https://universalscammerlist.com/search.php) | [Confirm Transactions and Increase Flair Score](https://www.reddit.com/r/GameSale/wiki/confirming_transactions)
 
 Username | Join date | Link karma | Comment karma
 :- | :-: | -: | -:


### PR DESCRIPTION
Usually this information is handed out by automod, but because you guys have a separate bot handling it, this bot needs to be updated to include a reference to the guide. It'll cut down on mod mail questions a good bit to have it here.